### PR TITLE
Html: generalise to monad transformer. add thead and tbody

### DIFF
--- a/src/Analyze/Html.hs
+++ b/src/Analyze/Html.hs
@@ -6,8 +6,10 @@ import           Control.Monad  (forM_)
 import qualified Lucid          as L
 
 -- | Renders an 'RFrame' to an HTML table.
-renderHtml :: (L.ToHtml k, L.ToHtml v) => RFrame k v -> L.Html ()
+renderHtml :: (L.ToHtml k, L.ToHtml v, Monad m)
+           => RFrame k v -> L.HtmlT m ()
 renderHtml (RFrame ks _ vs) =
   L.table_ $ do
-    L.tr_ $ forM_ ks (L.th_ . L.toHtml)
-    forM_ vs $ \v -> L.tr_ (forM_ v (L.td_ . L.toHtml))
+    L.thead_ $
+      L.tr_ $ forM_ ks (L.th_ . L.toHtml)
+    L.tbody_ $ forM_ vs $ \v -> L.tr_ (forM_ v (L.td_ . L.toHtml))


### PR DESCRIPTION
the monad transformer is compatible with any previous code as L.Html = L.HtmlT Identity

added thead and tbody as some JS libs seem to require them (e.g. DataTables.net)